### PR TITLE
fix: unmarshall spec customization

### DIFF
--- a/cmd/ocifit/main.go
+++ b/cmd/ocifit/main.go
@@ -52,7 +52,11 @@ type JSONPatch struct {
 
 // admit allows the request without modification
 func admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
-	log.Printf("Allowing pod %s/%s without mutation", ar.Request.Namespace, ar.Request.Name)
+	if ar.Request.Name != "" {
+		log.Printf("Allowing pod %s/%s: %s", ar.Request.Namespace, ar.Request.Name)
+	} else {
+		log.Printf("Allowing pod in namespace %s without mutation", ar.Request.Namespace)
+	}
 	return &admissionv1.AdmissionResponse{
 		Allowed: true,
 		UID:     ar.Request.UID,
@@ -61,7 +65,13 @@ func admit(ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
 
 // deny rejects the request with a message
 func deny(ar *admissionv1.AdmissionReview, message string) *admissionv1.AdmissionResponse {
-	log.Printf("Denying pod %s/%s: %s", ar.Request.Namespace, ar.Request.Name, message)
+
+	// Most pods don't have a name yet
+	if ar.Request.Name != "" {
+		log.Printf("Denying pod %s/%s: %s", ar.Request.Namespace, ar.Request.Name, message)
+	} else {
+		log.Printf("Denying pod in namespace %s: %s", ar.Request.Namespace, message)
+	}
 	return &admissionv1.AdmissionResponse{
 		Allowed: false,
 		UID:     ar.Request.UID,

--- a/example/ebpf-compatibility-spec.json
+++ b/example/ebpf-compatibility-spec.json
@@ -1,0 +1,85 @@
+{
+    "version": "v1alpha1",
+    "compatibilities": [
+        {
+            "tag": "ghcr.io/converged-computing/kernel-header-installer:ubuntu2204",
+            "description": "Compatibility for eBPF installer intended for Ubuntu 22.04 LTS nodes with kernel 6.1 or newer.",
+            "rules": [
+                {
+                    "matchFeatures": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "op": "In",
+                                    "key": "feature.node.kubernetes.io/system-os_release.ID",
+                                    "value": [
+                                        "ubuntu"
+                                    ]
+                                },
+                                {
+                                    "op": "In",
+                                    "key": "feature.node.kubernetes.io/system-os_release.VERSION_ID",
+                                    "value": [
+                                        "22.04"
+                                    ]
+                                },
+                                {
+                                    "op": "In",
+                                    "key": "feature.node.kubernetes.io/kernel-version.major",
+                                    "value": [
+                                        "6"
+                                    ]
+                                },
+                                {
+                                    "op": "Gte",
+                                    "key": "feature.node.kubernetes.io/kernel-version.minor",
+                                    "value": "1"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "tag": "ghcr.io/converged-computing/kernel-header-installer:fedora43",
+            "description": "Compatibility for eBPF installer intended for Amazon Linux 2023 nodes with kernel 6.1 or newer.",
+            "rules": [
+                {
+                    "matchFeatures": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "op": "In",
+                                    "key": "feature.node.kubernetes.io/system-os_release.ID",
+                                    "value": [
+                                        "amzn"
+                                    ]
+                                },
+                                {
+                                    "op": "In",
+                                    "key": "feature.node.kubernetes.io/system-os_release.VERSION_ID",
+                                    "value": [
+                                        "2023"
+                                    ]
+                                },
+                                {
+                                    "op": "In",
+                                    "key": "feature.node.kubernetes.io/kernel-version.major",
+                                    "value": [
+                                        "6"
+                                    ]
+                                },
+                                {
+                                    "op": "Gte",
+                                    "key": "feature.node.kubernetes.io/kernel-version.minor",
+                                    "value": "1"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -25,8 +25,10 @@ const (
 	MatchOpInRegexp     MatchOp = "InRegexp"
 	MatchOpExists       MatchOp = "Exists"
 	MatchOpDoesNotExist MatchOp = "DoesNotExist"
-	MatchOpGt           MatchOp = "Gt" // Greater than
-	MatchOpLt           MatchOp = "Lt" // Less than
+	MatchOpGt           MatchOp = "Gt"  // Greater than
+	MatchOpLt           MatchOp = "Lt"  // Less than
+	MatchOpGte          MatchOp = "Gte" // Greater than or equal to
+	MatchOpLte          MatchOp = "Lte" // Less than or equal to
 )
 
 // MatchExpression specifies a requirement for matching features.

--- a/pkg/types/unmarshal.go
+++ b/pkg/types/unmarshal.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// UnmarshalJSON implements a custom unmarshaler for MatchExpression to handle value
+func (m *MatchExpression) UnmarshalJSON(data []byte) error {
+	// 1. Define an alias type to avoid an infinite recursion loop.
+	//    If we called json.Unmarshal on MatchExpression inside this method,
+	//    it would call this method again (stack overflow).
+	type alias MatchExpression
+
+	// 2. Create a temporary struct to unmarshal into. value needs to be raw
+	temp := &struct {
+		Value json.RawMessage `json:"value"`
+		*alias
+	}{
+		// 3. Point the alias to the current MatchExpression instance ('m')
+		//    so that Op and Key are populated directly into it.
+		alias: (*alias)(m),
+	}
+
+	// 4. Unmarshal the data into our temporary struct.
+	if err := json.Unmarshal(data, &temp); err != nil {
+		return fmt.Errorf("failed to unmarshal match expression: %w", err)
+	}
+
+	// 5. Now, inspect the raw JSON for the 'value' field.
+	if len(temp.Value) > 0 {
+		// If the first character is '[', it's a JSON array.
+		if temp.Value[0] == '[' {
+			// Unmarshal it as a normal slice of strings.
+			if err := json.Unmarshal(temp.Value, &m.Value); err != nil {
+				return fmt.Errorf("failed to unmarshal 'value' as array: %w", err)
+			}
+		} else {
+			// Otherwise, assume it's a single JSON string.
+			var strValue string
+			if err := json.Unmarshal(temp.Value, &strValue); err != nil {
+				return fmt.Errorf("failed to unmarshal 'value' as string: %w", err)
+			}
+			// **This is the key step:** We normalize the single string
+			// into a slice containing just that string.
+			m.Value = []string{strValue}
+		}
+	}
+
+	return nil
+}

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -7,6 +7,19 @@ import (
 	"ghcr.io/compspec/ocifit-k8s/pkg/types"
 )
 
+// Make it pretty :)
+var (
+	Reset   = "\033[0m"
+	Red     = "\033[31m"
+	Green   = "\033[32m"
+	Yellow  = "\033[33m"
+	Blue    = "\033[34m"
+	Magenta = "\033[35m"
+	Cyan    = "\033[36m"
+	Gray    = "\033[37m"
+	White   = "\033[97m"
+)
+
 // evaluateCompatibilitySpec finds the best matching compatibility set from the spec
 // by evaluating its rules against the node's labels.
 func EvaluateCompatibilitySpec(spec *types.CompatibilitySpec, nodeLabels map[string]string) (string, error) {
@@ -16,6 +29,7 @@ func EvaluateCompatibilitySpec(spec *types.CompatibilitySpec, nodeLabels map[str
 	// Loop through each top-level Compatibility set in the spec.
 	for i, comp := range spec.Compatibilities {
 		allRulesMatch := true
+		log.Printf("Assessing compatibility of %s", comp.Tag)
 
 		// Each Compatibility set can have multiple GroupRules
 		// All GroupRules must match for the set to be considered a match (AND logic).
@@ -33,8 +47,11 @@ func EvaluateCompatibilitySpec(spec *types.CompatibilitySpec, nodeLabels map[str
 				for _, expression := range featureMatcher.MatchExpressions {
 					if !evaluateRule(expression, nodeLabels) {
 						// As soon as one expression fails, the entire Compatibility set is invalid.
+						log.Printf(Red+"  FAILED %s"+Reset, expression)
 						allRulesMatch = false
 						break
+					} else {
+						log.Printf(Green+"  PASSED %s"+Reset, expression)
 					}
 				}
 			}
@@ -42,7 +59,7 @@ func EvaluateCompatibilitySpec(spec *types.CompatibilitySpec, nodeLabels map[str
 
 		// If after checking all the rules for this set, allRulesMatch is still true...
 		if allRulesMatch {
-			log.Printf("Found a matching compatibility set: '%s' (weight %d)", comp.Tag, comp.Weight)
+			log.Printf("⭐ Found a matching compatibility set: '%s' (weight %d)\n", comp.Tag, comp.Weight)
 
 			// Check if this match is better (has a higher weight) than any previous match we found.
 			if comp.Weight > maxWeight {
@@ -59,6 +76,6 @@ func EvaluateCompatibilitySpec(spec *types.CompatibilitySpec, nodeLabels map[str
 		return "", fmt.Errorf("no matching compatibility rule found for the given node labels")
 	}
 
-	log.Printf("Selected best match: '%s' with highest weight %d", bestMatch.Tag, bestMatch.Weight)
+	log.Printf("Selected best match: '%s' with highest weight %d\n", bestMatch.Tag, bestMatch.Weight)
 	return bestMatch.Tag, nil
 }


### PR DESCRIPTION
For Gt and other comparison cases where we compare to a single value, we need to allow for Value to be single or a list. I am also adding better logging of passing, failure, and some colors, and the ebpf example.

Here is what it looks like to select the right eBPF installer image for a daemonset.

![image](https://github.com/user-attachments/assets/a0ca25ab-ebef-4337-a525-d612359b608f)
